### PR TITLE
feat(vault): add hardware-backed encryption and recovery

### DIFF
--- a/app/src/main/java/com/sentinoid/shield/OfflineRecovery.kt
+++ b/app/src/main/java/com/sentinoid/shield/OfflineRecovery.kt
@@ -1,0 +1,148 @@
+package com.sentinoid.shield
+
+import android.util.Base64
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import cash.z.ecc.android.bip39.Mnemonics
+import java.security.SecureRandom
+import java.util.*
+
+object OfflineRecovery {
+
+    private val random = SecureRandom()
+
+    /**
+     * Generates a 24-word recovery phrase.
+     */
+    fun generateMnemonic(): String {
+        val mnemonic = Mnemonics.MnemonicCode(Mnemonics.WordCount.COUNT_24)
+        val phrase = mnemonic.words.joinToString(" ") { String(it) }
+        mnemonic.clear()
+        return phrase
+    }
+
+    /**
+     * Splits a secret string into N shares, requiring T shares to reconstruct.
+     * Uses a Shamir Secret Sharing implementation over GF(256).
+     */
+    fun splitSecret(secret: String, shares: Int, threshold: Int): List<String> {
+        if (threshold > shares) throw IllegalArgumentException("Threshold cannot be greater than shares")
+        val secretBytes = secret.toByteArray()
+        val results = Array(shares) { ByteArray(secretBytes.size) }
+
+        for (i in secretBytes.indices) {
+            val poly = ByteArray(threshold)
+            poly[0] = secretBytes[i]
+            for (j in 1 until threshold) {
+                poly[j] = random.nextInt(256).toByte()
+            }
+
+            for (x in 1..shares) {
+                results[x - 1][i] = evaluatePolynomial(poly, x)
+            }
+        }
+
+        return results.mapIndexed { index, bytes ->
+            "${index + 1}:" + Base64.encodeToString(bytes, Base64.NO_WRAP)
+        }
+    }
+
+    /**
+     * Reconstructs the secret from a list of shares.
+     */
+    fun recoverSecret(shares: List<String>): String {
+        if (shares.isEmpty()) return ""
+        
+        val decodedShares = try {
+            shares.map {
+                val parts = it.split(":")
+                val x = parts[0].toInt()
+                val y = Base64.decode(parts[1], Base64.DEFAULT)
+                x to y
+            }
+        } catch (e: Exception) {
+            return ""
+        }
+
+        val secretSize = decodedShares[0].second.size
+        val secretBytes = ByteArray(secretSize)
+
+        for (i in 0 until secretSize) {
+            val points = decodedShares.map { it.first to (it.second[i].toInt() and 0xFF) }
+            secretBytes[i] = interpolate(points).toByte()
+        }
+
+        return String(secretBytes)
+    }
+
+    // GF(256) implementation details
+    private val exp = IntArray(512)
+    private val log = IntArray(256)
+
+    init {
+        var x = 1
+        for (i in 0 until 255) {
+            exp[i] = x
+            exp[i + 255] = x
+            log[x] = i
+            x = x shl 1
+            if (x >= 256) x = x xor 0x11D
+        }
+    }
+
+    private fun mul(a: Int, b: Int): Int {
+        if (a == 0 || b == 0) return 0
+        return exp[log[a] + log[b]]
+    }
+
+    private fun div(a: Int, b: Int): Int {
+        if (a == 0) return 0
+        if (b == 0) throw ArithmeticException("Division by zero")
+        return exp[log[a] + 255 - log[b]]
+    }
+
+    private fun evaluatePolynomial(poly: ByteArray, x: Int): Byte {
+        var result = 0
+        var xPow = 1
+        for (coeff in poly) {
+            result = result xor mul(coeff.toInt() and 0xFF, xPow)
+            xPow = mul(xPow, x)
+        }
+        return result.toByte()
+    }
+
+    private fun interpolate(points: List<Pair<Int, Int>>): Int {
+        var result = 0
+        for (i in points.indices) {
+            var basis = 1
+            for (j in points.indices) {
+                if (i == j) continue
+                val num = points[j].first
+                val den = points[j].first xor points[i].first
+                basis = mul(basis, div(num, den))
+            }
+            result = result xor mul(basis, points[i].second)
+        }
+        return result
+    }
+}
+
+@Composable
+fun BIP39Words(mnemonic: String, onProceed: () -> Unit) {
+    Column(modifier = Modifier.padding(16.dp)) {
+        Text("Write down your 24-word recovery phrase:")
+        Spacer(modifier = Modifier.height(16.dp))
+        Text(mnemonic)
+        Spacer(modifier = Modifier.height(16.dp))
+        Button(onClick = onProceed) {
+            Text("Proceed")
+        }
+    }
+}

--- a/docs/BRANCH_README.md
+++ b/docs/BRANCH_README.md
@@ -1,0 +1,112 @@
+# 🔐 Feature: Security Vault
+
+## Overview
+
+This branch implements the core cryptographic infrastructure for Sentinoid, providing hardware-backed encryption with biometric authentication and secure key management.
+
+## What's Included
+
+### Core Components
+- **VaultService.kt** - AES-256-GCM encryption/decryption with Android Keystore
+- **KeyManager.kt** - SQLCipher passphrase generation and storage
+- **OfflineRecovery.kt** - BIP39 mnemonic generation + Shamir Secret Sharing
+- **SecurityModule.kt** - Keystore initialization with biometric binding
+
+### Data Layer
+- **Secret.kt** - Entity for encrypted secrets storage
+- **SecretDao.kt** - Room DAO for database operations
+- **SecretRepository.kt** - Repository pattern implementation
+- **SecretViewModel.kt** - MVVM ViewModel for UI interaction
+- **SovereignDatabase.kt** - SQLCipher-encrypted Room database
+- **SecurityModels.kt** - Data classes for security operations
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                    BiometricPrompt                             │
+└─────────────────────────────────────────────────────────────┘
+                              ↓
+┌─────────────────────────────────────────────────────────────┐
+│              Android Keystore / StrongBox                    │
+│  • Keys never leave secure silicon                           │
+│  • Biometric binding enforced at hardware level             │
+└─────────────────────────────────────────────────────────────┘
+                              ↓
+┌─────────────────────────────────────────────────────────────┐
+│                   AES-256-GCM Engine                         │
+│  • VaultService: File and string encryption                │
+│  • SQLCipher: Database encryption with passphrase            │
+└─────────────────────────────────────────────────────────────┘
+```
+
+## Key Features
+
+| Feature | Implementation | Security Property |
+|---------|---------------|-------------------|
+| Hardware-backed keys | Android Keystore / StrongBox | Keys never in application memory |
+| Biometric binding | `setUserAuthenticationRequired(true)` | No biometric = no decryption |
+| Anti-tamper | `setInvalidatedByBiometricEnrollment(true)` | Auto-key-wipe on new enrollment |
+| Database encryption | SQLCipher + hardware-derived passphrase | Double encryption layer |
+| Recovery | BIP39 24-word + Shamir Secret Sharing | Offline, distributed backup |
+
+## Usage
+
+```kotlin
+// Initialize vault service
+val vaultService = VaultService()
+
+// Encrypt data (requires biometric)
+val (cipherText, iv) = vaultService.encryptString("sensitive data")
+
+// Decrypt (biometric prompt shown automatically)
+val plainText = vaultService.decryptString(cipherText, iv)
+
+// Database with encryption
+val passphrase = KeyManager.getOrCreatePassphrase(context)
+val db = Room.databaseBuilder(context, SovereignDatabase::class.java, "vault.db")
+    .openHelperFactory(SupportFactory(passphrase))
+    .build()
+```
+
+## Integration with Main
+
+This branch provides the foundation that other features depend on:
+- FPM Interceptor stores logs in encrypted database
+- Honeypot uses vault for intrusion evidence
+- Malware Scanner stores threat intelligence securely
+
+## Dependencies
+
+```kotlin
+implementation("androidx.security:security-crypto:1.1.0-alpha06")
+implementation("androidx.biometric:biometric:1.1.0")
+implementation("net.zetetic:android-database-sqlcipher:4.5.4")
+implementation("androidx.room:room-runtime:2.6.1")
+implementation("cash.z.ecc.android:kotlin-bip39:1.0.4")
+```
+
+## Testing
+
+```bash
+# Test biometric binding
+adb shell am start -n com.sentinoid.shield/.MainActivity
+
+# Verify key invalidation after adding fingerprint
+# Keys should be automatically invalidated
+```
+
+## Merge Checklist
+
+- [ ] All cryptographic operations tested
+- [ ] Biometric prompt works correctly
+- [ ] Database encryption verified
+- [ ] BIP39 recovery phrase generation tested
+- [ ] Key invalidation on new biometric enrollment verified
+
+## Security Considerations
+
+- Keys are hardware-bound and cannot be exported
+- Recovery phrase must be written down and stored physically secure
+- SQLCipher provides defense-in-depth for database content
+- Biometric requirements prevent unauthorized decryption even with root access


### PR DESCRIPTION
Add complete cryptographic infrastructure:

- VaultService: AES-256-GCM with Android Keystore integration

- KeyManager: SQLCipher passphrase generation and secure storage

- OfflineRecovery: BIP39 mnemonic + Shamir Secret Sharing implementation

- SecurityModule: Biometric-bound key generation with anti-tamper

- Secret data layer: Room entities, DAOs, Repository, ViewModel

- SovereignDatabase: SQLCipher-encrypted database with hardware-derived keys

Security features:

- Hardware-backed keys (StrongBox when available)

- Mandatory biometric authentication for decryption

- Automatic key invalidation on new biometric enrollment

- Double encryption: SQLCipher + hardware-backed AES-GCM

- Offline recovery with 24-word BIP39 + SSS

### Description
<!-- What this PR does and why it’s needed. -->

### Related Issue
<!-- Reference the issue related to this PR -->
<!-- Example: Closes #12 -->

### Type of Change
<!-- Check all that apply -->
<!-- To check the box add a cross like this [x] -->
- [ ] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Tests added/updated
- [ ] Documentation update

### Key changes
<!-- List key changes here-->

### Related Photos/Videos/Logs
 <!-- Working photo, video or log -->

### How to Test the Changes
<!-- Steps to verify this PR works as expected -->
1.
2.

---
### Additional Notes for Maintainers (optional)
<!-- optional: context, trade-offs, or follow-ups -->
